### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-RTC KEYWORD1
+RTC	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setDate KEYWORD2
-getDate KEYWORD2
-setTime KEYWORD2
-getTime KEYWORD2
+setDate	KEYWORD2
+getDate	KEYWORD2
+setTime	KEYWORD2
+getTime	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -26,6 +26,6 @@ getTime KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-RTC_MAIN LITERAL1
-RTC_ALM0 LITERAL1
-RTC_ALM1 LITERAL1
+RTC_MAIN	LITERAL1
+RTC_ALM0	LITERAL1
+RTC_ALM1	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords